### PR TITLE
fix: add dash to the help recommendation list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ VITE_TWITCH_CLIENT_SECRET
 
 ## ¿Quieres contribuir? Aquí algunas cosas que puedes mejorar
 
-[x] Mejorar diseño de la computadora
-[ ] Mejorar animación `glitch`
-[ ] Mejorar instrucciones para crear un overlay
+- [x] Mejorar diseño de la computadora
+- [ ] Mejorar animación `glitch`
+- [ ] Mejorar instrucciones para crear un overlay


### PR DESCRIPTION
Actualmente README.md se ve así:
![image](https://github.com/user-attachments/assets/b1e35789-6b8e-4011-9e63-fe79e6881204)

Con este parche se vería así:
![image](https://github.com/user-attachments/assets/a9d7a9d3-6737-41ca-821c-2c3b348c674b)
